### PR TITLE
Fix issue #17 - unsigned char cursordata[]

### DIFF
--- a/src/RHTML_bmenu.cpp
+++ b/src/RHTML_bmenu.cpp
@@ -418,7 +418,7 @@ void RHTMLbmenu::MouseMoved(BPoint where, uint32 code, const BMessage *a_message
   }
  }
 
- char cursordata[] = {
+ unsigned char cursordata[] = {
 		0x10,0x01,0x07,0x07,
 		0x02,0x80,
 		0x02,0x80,


### PR DESCRIPTION
As described in issue #17, there's an error: narrowing conversion of '128' from 'int' to 'cha'
which can be  easily fixed by changing char cursordata[] to unsigned char cursordata[]